### PR TITLE
changed gdk/gio/glib sharp references

### DIFF
--- a/KeePass2PCL.Test.Desktop/KeePass2PCL.Test.Desktop.csproj
+++ b/KeePass2PCL.Test.Desktop/KeePass2PCL.Test.Desktop.csproj
@@ -58,15 +58,9 @@
       <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="gdk-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <Package>gtk-sharp-3.0</Package>
-    </Reference>
-    <Reference Include="gio-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <Package>gio-sharp-3.0</Package>
-    </Reference>
-    <Reference Include="glib-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <Package>glib-sharp-3.0</Package>
-    </Reference>
+    <Reference Include="gdk-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f"/>
+    <Reference Include="gio-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f"/>
+    <Reference Include="glib-sharp, Version=3.0.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f"/>
   </ItemGroup>
   <Import Project="..\KeePass2PCL.Test.Shared\KeePass2PCL.Test.Shared.projitems" Label="Shared" Condition="Exists('..\KeePass2PCL.Test.Shared\KeePass2PCL.Test.Shared.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
changed assembly references to not include a package name as I could not build with those package names in, but have no problem with them removed

I had a few problems when building due to a few lines in [KeePass2PCL.Test.Desktop.csproj](https://github.com/dlech/KeePass2PCL/blob/master/KeePass2PCL.Test.Desktop/KeePass2PCL.Test.Desktop.csproj)

Hopefully this isn't an issue of incompatibility in our environments. If you can still build without changing the assembly references back let me know.

A couple times monodevelop managed to figure it out on it's own, but what I did is exactly how monodevelop automatically changed the .csproj file anyway.
